### PR TITLE
Update view templates in admin scaffold

### DIFF
--- a/lib/generators/butler/templates/views/_form.html.haml
+++ b/lib/generators/butler/templates/views/_form.html.haml
@@ -1,24 +1,30 @@
-.panel.panel-default
+.panel.panel-success
   .panel-heading
     .panel-actions.pull-right
-      %button.btn-action{ data: { toggle: 'panel' } }
-        = fa_icon 'chevron-up'
+      - unless @<%= singular_table_name %>.new_record?
+        = link_to <%= prefixed_plain_model_url %>_path(@<%= singular_table_name %>), class: 'btn-action btn-bordered' do
+          = fa_icon 'eye', text: t('.show', default: t("helpers.links.show"))
+
+        = link_to '#', target: '_blank', class: 'btn-action btn-bordered' do
+          = fa_icon 'external-link-square', text: t('.preview', default: t("helpers.links.preview"))
 
     %h3.panel-title
       Attribute
 
   .panel-body
-    = simple_form_for [:admin, @<%= singular_table_name %>], html: { class: 'form form-horizontal <%= singular_table_name %>' } do |f|
-      .col-md-12
+    = simple_form_for [:admin, @<%= singular_table_name %>], html: {  class: 'form <%= singular_table_name %>' } do |f|
+      .row-grey
+        .col-md-12
 <% for attribute in attributes -%>
 <% if attribute.type == :datetime || attribute.type == :date -%>
-        = f.input :<%= attribute.name %>, label: t('headers.<%= attribute.name %>'), as: :string, input_html: { class: 'datepicker' }
+          = f.input :<%= attribute.name %>, label: t('headers.<%= attribute.name %>'), as: :string, input_html: { class: 'datepicker' }
 <% elsif attribute.type == :boolean -%>
-        = f.input :<%= attribute.name %>, inline_label: t('headers.<%= attribute.name %>'), as: :boolean, boolean_style: :inline, label: false, wrapper: :nc_admin_ui_cb
+           = f.input :<%= attribute.name %>, inline_label: t('headers.<%= attribute.name %>'), as: :boolean, boolean_style: :inline, label: false, wrapper: :nc_admin_ui_cb
 <% else -%>
-        = f.input :<%= attribute.name %>, label: t('headers.<%= attribute.name %>')
+          = f.input :<%= attribute.name %>, label: t('headers.<%= attribute.name %>')
 <% end -%>
 <% end -%>
-
-        = f.submit t('.create', default: t('helpers.links.create')), class: 'btn btn-primary'
-        = link_to t('.cancel', default: t('helpers.links.cancel')), <%= prefixed_index_helper %>_path, class: 'btn btn-grey'
+      .row
+        .col-md-12
+          = f.submit t('.create', default: t('helpers.links.create')), class: 'btn btn-primary'
+          = link_to t('.cancel', default: t('helpers.links.cancel')), <%= prefixed_index_helper %>_path, class: 'btn btn-grey'

--- a/lib/generators/butler/templates/views/index.html.haml
+++ b/lib/generators/butler/templates/views/index.html.haml
@@ -1,30 +1,29 @@
 - model_class = <%= class_name %>
 
-.page-content-header
-  .container-flex
-    %h3= t '.title', default: model_class.model_name.human(count: 2)
-
 .content
   .container-flex
     .row
       .col-md-12
+        = render 'layouts/admin/search', resource: :<%= plural_table_name %>
+
+      .col-md-12
         .panel.panel-success
           .panel-heading
             .panel-actions.pull-right
-              = button_to new_<%= prefixed_plain_model_url %>_path, class: 'btn-action btn-bordered', method: :get do
+              = link_to new_<%= prefixed_plain_model_url %>_path, class: 'btn-action btn-bordered' do
                 = fa_icon 'plus', text: t('.new', default: t('helpers.links.new'))
 
             %h3.panel-title
-              = model_class.model_name.human(count: 2)
+              = "#{model_class.model_name.human(count: 2)}s (#{@<%= plural_table_name %>.count})"
 
           .panel-body
             %table.table.table-bordered
-              %thead
+              %sortable_table_header
                 %tr
 <% for attribute in attributes -%>
-                  %th= t('headers.<%= attribute.name %>')
+                  %th= sortable_table_header('<%= attribute.name %>', :<%= attribute.name %>, lambda { |q| <%= prefixed_index_helper %>_path(q) })
 <% end -%>
-                  %th= t('headers.created_at')
+                  %th= sortable_table_header('created_at', :created_at, lambda { |q| <%= prefixed_index_helper %>_path(q) })
                   %th &nbsp;
 
               %tbody
@@ -33,13 +32,14 @@
 <% for attribute in attributes -%>
                     %td= <%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
-                    %td= l <%= singular_table_name %>.created_at, format: :date
-                    %td.full-width-buttons{ width: '150px' }
-                      = link_to <%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), class: 'btn btn-tiny' do
-                        = t('.show', default: t('helpers.links.show'))
+                    %td= format_datetime <%= singular_table_name %>.created_at
+                    %td{ width: '120px' }
+                      .btn-group
+                        = link_to <%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), class: 'btn btn-tiny btn-grey', title: t('.show', default: t('helpers.links.show')) do
+                          = fa_icon 'eye'
 
-                      = link_to edit_<%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), class: 'btn btn-grey btn-tiny' do
-                        = t('.edit', default: t('helpers.links.edit'))
+                        = link_to edit_<%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), class: 'btn btn-grey btn-tiny', title: t('.edit', default: t('helpers.links.edit')) do
+                          = fa_icon 'edit'
 
-                      = button_to <%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), method: :delete, data: { confirm: t('.confirm', default: t('helpers.links.confirm', default: 'Are you sure?')) }, class: 'btn btn-danger btn-tiny' do
-                        = t('.destroy', default: t('helpers.links.destroy'))
+                        = button_to <%= prefixed_plain_model_url %>_path(<%= singular_table_name %>), method: :delete, data: { confirm: t('.confirm', default: t('helpers.links.confirm', default: 'Are you sure?')) }, class: 'btn btn-danger btn-tiny', title: t('.destroy', default: t('helpers.links.destroy')) do
+                          = fa_icon 'trash'

--- a/lib/generators/butler/templates/views/show.html.haml
+++ b/lib/generators/butler/templates/views/show.html.haml
@@ -1,29 +1,25 @@
-- model_class = <%= class_name %>
-
-.page-content-header
-  .container-flex
-    %h3=t '.title', default: model_class.model_name.human.titleize
-
 .content
   .container-flex
     .row
       .col-md-12
         .panel.panel-success
           .panel-heading
+            .panel-actions.pull-right
+              = link_to <%= prefixed_plain_model_url %>_path(@<%= singular_table_name %>), method: 'delete', data: { confirm: t('.confirm', default: t('helpers.links.confirm_delete', default: 'Are you sure?')) }, class: 'btn btn-danger' do
+                = fa_icon 'trash'
+
+              = link_to edit_<%= prefixed_plain_model_url %>_path(@<%= singular_table_name %>), class: 'btn-action btn-bordered' do
+                = fa_icon 'edit', text: t('.edit', default: t("helpers.links.edit"))
+
             %h3.panel-title
-              = "<%= singular_table_name.titleize %>: ##{@<%= singular_table_name %>.id}"
+              = link_to <%= prefixed_index_helper %>_path, class: 'btn' do
+                = fa_icon 'chevron-left'
+              = "<%= plural_table_name.titleize %>: ##{@<%= singular_table_name %>.id}"
 
           .panel-body
-            %table.table.table-bordered
+            %table.table.table-bordered.table-fixed-th
 <% for attribute in attributes -%>
               %tr
                 %th.nowrap= t('headers.<%= attribute.name %>')
                 %td= @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
-
-            %br
-
-            .actions
-              = link_to t('.back', default: t('helpers.links.back')), <%= prefixed_index_helper %>_path, class: 'btn btn-default btn-tiny'
-              = link_to t('.edit', default: t('helpers.links.edit')), edit_<%= prefixed_plain_model_url %>_path(@<%= singular_table_name %>), class: 'btn btn-info btn-tiny'
-              = link_to t('.destroy', default: t('helpers.links.destroy')), <%= prefixed_plain_model_url %>_path(@<%= singular_table_name %>), method: 'delete', data: { confirm: t('.confirm', default: t('helpers.links.confirm', default: 'Are you sure?')) }, class: 'btn btn-danger btn-tiny'


### PR DESCRIPTION
The view templates are out of date and are to be updated according to what the current CMS looks like in echo-live.

Things that should be considered here:

`show`
- content linking
- images upload form

`_form`
- I left left the external “preview/vorshau” button in there (links to no where), should decide whether to remove this or not.
